### PR TITLE
Fix vector example to work on systems without concurrent managed access

### DIFF
--- a/posts/cuda-vmm/cuvector.h
+++ b/posts/cuda-vmm/cuvector.h
@@ -87,6 +87,8 @@ private:
     CUdeviceptr d_p;
     size_t alloc_sz;
     size_t reserve_sz;
+    // Attribute query to see if cuMemPrefetchAsync is available to the target device.
+    int supportsConcurrentManagedAccess;
 
 public:
     VectorMemAllocManaged(CUcontext context);


### PR DESCRIPTION
Prevent an error from occurring with the vector example on systems without concurrent managed access that do not support cuMemPrefetchAsync