### PR TITLE
Removing unsupported architectures

### DIFF
--- a/posts/cuda-aware-mpi-example/src/Makefile
+++ b/posts/cuda-aware-mpi-example/src/Makefile
@@ -34,15 +34,12 @@ CFLAGS=-std=c99 -O3 -march=native -Wall
 MPICFLAGS=-I${MPI_HOME}/include
 CUDACFLAGS=-I${CUDA_INSTALL_PATH}/include
 
-GENCODE_SM30    := -gencode arch=compute_30,code=sm_30
-GENCODE_SM35    := -gencode arch=compute_35,code=sm_35
-GENCODE_SM35    := -gencode arch=compute_37,code=sm_37
 GENCODE_SM50    := -gencode arch=compute_50,code=sm_50
 GENCODE_SM52    := -gencode arch=compute_52,code=sm_52
 GENCODE_SM60    := -gencode arch=compute_60,code=sm_60
 GENCODE_SM70    := -gencode arch=compute_70,code=\"sm_70,compute_70\"
-GENCODE_FLAGS   := $(GENCODE_SM30) $(GENCODE_SM35) $(GENCODE_SM37)             \
-$(GENCODE_SM50) $(GENCODE_SM52) $(GENCODE_SM60) $(GENCODE_SM70)
+GENCODE_FLAGS   := $(GENCODE_SM50) $(GENCODE_SM52) $(GENCODE_SM60) $(GENCODE_SM70)
+
 
 NVCCFLAGS=-O3 $(GENCODE_FLAGS) -Xcompiler -march=native
 


### PR DESCRIPTION
The examples do not compile on modern CUDA environments.
Ancient architectures have been removed from the Makefile