### PR TITLE
Printf-alternative blog files

### DIFF
--- a/posts/printf-alternative/CASerror.h
+++ b/posts/printf-alternative/CASerror.h
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <iostream>
+#include <stdio.h>
+#include <assert.h>
+#include "cuda.h"
+#include <memory>
+#include <cuda/atomic>
+
+namespace CASError {
+
+  enum AtomicStatus {
+    ATOMIC_NO_ERROR = 0,
+    ATOMIC_ERROR_REPORTED = 1
+  };
+
+  inline
+  cudaError_t checkCuda(cudaError_t result)
+  {
+  #if defined(DEBUG) || defined(_DEBUG)
+    if (result != cudaSuccess) {
+      fprintf(stderr, "CUDA Runtime Error: %s\n", 
+              cudaGetErrorString(result));
+      assert(result == cudaSuccess);
+    }
+  #endif
+    return result;
+  }
+
+  // Allocates system-pinned memory of type ErrorType
+  template < typename ErrorType>
+  struct PinnedMemory 
+  {
+      using data_type = ErrorType;
+
+      PinnedMemory() {
+          checkCuda(cudaMallocHost(&hdata, sizeof(data_type)));
+      }
+
+      ~PinnedMemory(){
+          cudaFreeHost(hdata);
+      }
+      data_type *hdata;
+  };
+
+  // DeviceStatus allocates system-pinned memory of StatusType and also allocates corresponding device memory of StatusType
+  template <typename StatusType>
+  struct DeviceStatus
+  {
+
+      using status_type = StatusType;
+
+      DeviceStatus () {
+          checkCuda(cudaMallocHost(&host_status, sizeof(status_type), cudaHostAllocMapped));
+          checkCuda(cudaMalloc(&device_status, sizeof(status_type)));
+      }
+
+      ~DeviceStatus() {
+          checkCuda(cudaFreeHost(host_status));
+          checkCuda(cudaFree(device_status));
+      }    
+
+      status_type __host__ status() {
+        return static_cast<volatile cuda::std::atomic<StatusType> *>(host_status)->load(cuda::memory_order_acquire);
+      }
+
+      cuda::std::atomic<StatusType> *host_status;
+      StatusType *device_status;
+  };
+
+  // This struct represents the data accessible and modifiable on the device and contains pointers to relevant information
+  template <typename ErrorType>
+  struct MappedErrorTypeDeviceData {
+        using status_type = AtomicStatus;
+        // these two members are used so that they can be accessed from the device directly
+        cuda::std::atomic<status_type> * host_status;
+        status_type * device_status;
+
+        // pointer to pinned data to be accessed from the device directly
+        ErrorType * host_data; 
+
+        void inline __device__ synchronizeStatus() {
+          host_status->store(ATOMIC_ERROR_REPORTED, cuda::memory_order_release);
+        }   
+      };
+
+
+  /* The MappedErrorType creates system-pinned memory of ErrorType, as well as corresponding DeviceStatus. 
+  * Using the available methods guarantees the necessary memory fences to avoid asynchronous race conditions.
+  */ 
+
+  template <typename ErrorType>
+  struct MappedErrorType 
+  {
+      // Use same status type as MappedErrorTypeDeviceData
+      using status_type = typename MappedErrorTypeDeviceData<ErrorType>::status_type;
+
+      // System-pinned error payload to be written by supplied function
+      std::shared_ptr<PinnedMemory<ErrorType>> error_data;
+
+      // Error reporting indicator to coordinate asynchronous soft error reporting
+      std::shared_ptr<DeviceStatus<status_type>> status;
+
+      // The necessary device-side pointers needed for proper reporting
+      MappedErrorTypeDeviceData<ErrorType> deviceData;
+
+      MappedErrorType (cudaStream_t stream = 0) 
+      : error_data(new PinnedMemory<ErrorType>()),
+        status(new DeviceStatus<status_type>()),
+        deviceData (MappedErrorTypeDeviceData<ErrorType>{.host_status =status->host_status,
+                              .device_status =status->device_status, 
+                              .host_data = error_data->hdata})
+      { 
+        deviceData.host_status->store(ATOMIC_NO_ERROR, cuda::memory_order_release);
+        checkCuda(cudaMemsetAsync(deviceData.device_status, ATOMIC_NO_ERROR, sizeof(status_type), stream));
+      }
+
+      /// Checks on the host if an error has been reported
+      bool __host__ checkErrorReported() {
+        return (status->status() == ATOMIC_ERROR_REPORTED);
+      }
+
+      /** Returns host-pinned error payload
+      * Note: If error data includes device pointers (e.g. const char*) you will need to properly post-processes these pointers
+      */
+      volatile ErrorType & __host__ get() {
+        return *static_cast<volatile ErrorType *>(deviceData.host_data);
+      }
+
+      /// Clears both the device-side status and host-side 
+      void __host__ clear(cudaStream_t stream = 0) {
+        checkCuda(cudaMemsetAsync(deviceData.device_status, ATOMIC_NO_ERROR, sizeof(status_type), stream));
+        (deviceData.host_status)->store(ATOMIC_NO_ERROR, cuda::memory_order_release);
+      }
+
+      void inline __device__ synchronizeStatus() {
+        deviceData.synchronizeStatus();
+      }
+
+  };
+
+  /// Retrieve variable like __FILE__ when set in device memory to host
+  std::string getDeviceString(const char * device_string, cudaStream_t stream = 0) {
+      CUdeviceptr pbase;
+      std::size_t psize;
+      cuMemGetAddressRange(&pbase, &psize, reinterpret_cast<CUdeviceptr>(device_string));
+      std::string str;
+      str.resize(psize);
+      cudaMemcpyAsync(str.data(), device_string, psize, cudaMemcpyDeviceToHost, stream);    
+      return str;  
+  }
+
+  template <typename ErrorType, typename FunctionType>
+  inline __device__ void report_first_error(MappedErrorType<ErrorType> & error_dat, FunctionType func){
+      if (atomicCAS(reinterpret_cast<int*>(error_dat.deviceData.device_status), static_cast<int>(ATOMIC_NO_ERROR), static_cast<int>(ATOMIC_ERROR_REPORTED)) == static_cast<int>(ATOMIC_NO_ERROR) ) {
+          func(*error_dat.deviceData.host_data);
+          __threadfence_system();
+          error_dat.synchronizeStatus();
+      }
+  }
+
+}

--- a/posts/printf-alternative/CMakeLists.txt
+++ b/posts/printf-alternative/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+project(error_example CXX CUDA)
+
+set(CMAKE_CUDA_ARCHITECTURES "60;70;80")
+
+find_package(CUDAToolkit REQUIRED)
+
+add_executable(error_example main.cu )
+target_link_libraries(error_example CUDA::cuda_driver)
+target_compile_options(error_example PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
+                       --generate-line-info
+                       #-G
+                       #-g
+                       --extended-lambda
+                       -Xptxas=-v
+                       >)
+

--- a/posts/printf-alternative/README.md
+++ b/posts/printf-alternative/README.md
@@ -1,0 +1,3 @@
+# Printf-alternative
+
+Often times users may be tempted to use `printf` to signal soft warnings; however the compiler may reserve extra registers for `printf` even if the warning rarely occurs. This in turn can affect performance. The `CASerror.h` header-only library implements a performant soft-warning printf-alternative using cuda atomics and system pinned memory. An example of how to use this header-only library in action is provided in `main.cu`.

--- a/posts/printf-alternative/main.cu
+++ b/posts/printf-alternative/main.cu
@@ -1,0 +1,304 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <stdio.h>
+#include <assert.h>
+#include "cuda.h"
+#include "CASerror.h"
+
+enum codes
+{
+    NO_ERROR = 0,
+    RANGE_ERROR = 1,
+    LARGE_VALUE_ERROR = 2,
+    NEG_SQRT_ERROR = 3,
+    UNSPECIFIED_ERROR = 999,
+};
+
+struct RandomSpikeError {
+    
+    int code;
+    int line;
+    int filenum;
+    int block;
+    int thread;
+    // payload information
+    int idx;
+    float val;
+};
+
+struct OtherError {
+    
+    int code;
+    int line;    
+    int block;
+    int thread;
+    const char* file;
+    int idx;
+};
+
+__global__ void randomSpikeKernel(float* out, int sz)
+// This kernel generates a pseudo-random number 
+// then puts it into 1/num-100+1e-6. That curve will be 
+// sharply peaked at num=100 where the value will be 1e6.
+// In the case of a very large value, we want to report an
+// error without stopping the kernel.
+{
+   for (int idx = threadIdx.x + blockIdx.x * blockDim.x;
+       idx < sz;
+       idx += blockDim.x * gridDim.x)
+   {
+       const int A = 187;
+       const int M = 7211;
+       int ival = ((idx + A) * A) % M;
+       ival = (ival*A) % M;
+       ival = (ival*A) % M;
+       float val = 1.f/(ival-100+1e-6);
+       
+       out[idx] = val;
+   } 
+}
+
+__global__ void randomSpikeKernelwAssert(float* out, int sz)
+// This kernel generates a pseudo-random number 
+// then puts it into 1/num-100+1e-6. That curve will be 
+// sharply peaked at num=100 where the value will be 1e6.
+// In the case of a very large value, we want to report an
+// error without stopping the kernel.
+{
+   for (int idx = threadIdx.x + blockIdx.x * blockDim.x;
+       idx < sz;
+       idx += blockDim.x * gridDim.x)
+   {
+       const int A = 187;
+       const int M = 7211;
+       int ival = ((idx + A) * A) % M;
+       ival = (ival*A) % M;
+       ival = (ival*A) % M;
+       float val = 1.f/(ival-100+1e-6);
+       assert(val < 10000);
+       
+       out[idx] = val;
+   } 
+}
+__global__ void randomSpikeKernelwError(float* out, int sz)
+// This kernel generates a pseudo-random number 
+// then puts it into 1/num-100+1e-6. That curve will be 
+// sharply peaked at num=100 where the value will be 1e6.
+// In the case of a very large value, we want to report an
+// error without stopping the kernel.
+{
+   for (int idx = threadIdx.x + blockIdx.x * blockDim.x;
+       idx < sz;
+       idx += blockDim.x * gridDim.x)
+   {
+       const int A = 187;
+       const int M = 7211;
+       int ival = ((idx + A) * A) % M;
+       ival = (ival*A) % M;
+       ival = (ival*A) % M;
+       float val = 1.f/(ival-100+1e-6);
+       
+       if (val >= 10000) {
+//          assert(val < sz);
+            printf("val (%f) out of range for idx = %d\n", val, idx);
+       }
+       out[idx] = val;
+   } 
+}
+
+__global__ void randomSpikeKernelFinal(float* out, int sz, CASError::MappedErrorType<RandomSpikeError> device_error_data)
+// This kernel generates a pseudo-random number 
+// then puts it into 1/num-100+1e-6. That curve will be 
+// sharply peaked at num=100 where the value will be 1e6.
+// In the case of a very large value, we want to report an
+// error without stopping the kernel.
+{
+   for (int idx = threadIdx.x + blockIdx.x * blockDim.x;
+       idx < sz;
+       idx += blockDim.x * gridDim.x)
+   {
+       const int A = 187;
+       const int M = 7211;
+       int ival = ((idx + A) * A) % M;
+       ival = (ival*A) % M;
+       ival = (ival*A) % M;
+       float val = 1.f/(ival-100+1e-6);
+       
+       if (val >= 10000) {
+        report_first_error(device_error_data, [&] (auto &error){
+               error = RandomSpikeError {
+                  .code = LARGE_VALUE_ERROR,
+                  .line = __LINE__,
+                  .filenum = 0,
+                  .block = static_cast<int>(blockIdx.x),
+                  .thread = static_cast<int>(threadIdx.x),
+                  .idx = idx,
+                  .val = val
+               };
+        });        
+       }
+       out[idx] = val;
+   } 
+}
+
+__global__ void otherKernel(float* inout, int sz, CASError::MappedErrorType<OtherError> device_error_data)
+// This kernel computes the sqrt of the input values. Where the input
+// value is negative, we raise an error
+{
+   for (int idx = threadIdx.x + blockIdx.x * blockDim.x;
+       idx < sz;
+       idx += blockDim.x * gridDim.x)
+   {
+      
+       float val = inout[idx];
+       if (val < 0) {
+         report_first_error(device_error_data, [&] (auto &error){
+               error = OtherError {
+                  .code = NEG_SQRT_ERROR,
+                  .line = __LINE__,
+                  .block = static_cast<int>(blockIdx.x),               
+                  .thread = static_cast<int>(threadIdx.x),
+                  .file = __FILE__,
+                  .idx = idx
+               };
+        });        
+       } else inout[idx] = sqrt(val);
+   }
+}
+
+int reportError( CASError::MappedErrorType<RandomSpikeError> & error_dat)
+{
+   int retval = NO_ERROR;
+   
+   if (error_dat.checkErrorReported()) {
+      auto & error = error_dat.get();
+      retval = error.code;
+      std::cerr << "ERROR " << error.code
+                << ", line " << error.line
+                << ". block " << error.block
+                << ", thread " << error.thread;
+      if (retval == LARGE_VALUE_ERROR)
+        std::cerr << ", value = " << error.val;
+      std::cerr << std::endl;     
+   }
+   
+   return retval;
+}
+
+int reportError( CASError::MappedErrorType<OtherError> & error_dat, cudaStream_t stream = 0)
+{
+   int retval = NO_ERROR;
+   
+   if (error_dat.checkErrorReported()) {
+      auto & error = error_dat.get();
+      retval = error.code;
+      std::cerr << "ERROR " << error.code
+                << ", line " << error.line
+                << ", file " << CASError::getDeviceString(error.file, stream)
+                << ". block " << error.block
+                << ", thread " << error.thread;
+      std::cerr << std::endl;     
+   }
+   
+   return retval;
+}
+
+#define MAX_IDX 7000
+int main(void)
+{
+   int device;
+   cudaDeviceProp prop;
+   CASError::checkCuda(cudaGetDevice(&device));
+   CASError::checkCuda(cudaGetDeviceProperties(&prop, device));
+
+   if (prop.concurrentManagedAccess) std::cout << "concurrentManagedAccess supported" << std::endl;
+   if (prop.hostNativeAtomicSupported) std::cout << "hostNativeAtomicSupported supported" << std::endl;
+
+   // Create pinned flags/data and device-side atomic flag for CAS
+   auto mapped_error = CASError::MappedErrorType<RandomSpikeError>();
+   auto mapped_error2 = CASError::MappedErrorType<OtherError>();
+
+   int async_err;
+
+   // Streams and events
+   cudaStream_t stream; cudaStreamCreate(&stream);
+   cudaEvent_t finishedRandomSpikeKernel;
+   CASError::checkCuda( cudaEventCreate(&finishedRandomSpikeKernel) );
+   cudaEvent_t finishedOtherKernel;
+   CASError::checkCuda( cudaEventCreate(&finishedOtherKernel) );   
+
+   float *out;
+   auto h_out = new float [MAX_IDX];
+   cudaMalloc((void**)&out, sizeof(float)*MAX_IDX);
+
+   randomSpikeKernel<<<100,32,0,stream>>>(out, MAX_IDX);
+
+   randomSpikeKernelFinal<<<100,32,0,stream>>>(out, MAX_IDX, mapped_error);
+   CASError::checkCuda( cudaEventRecord(finishedRandomSpikeKernel, stream) );
+   
+#if 0
+   CASError::checkCuda(cudaEventSynchronize(finishedRandomSpikeKernel));
+#endif
+   // Check the error message from err_data
+   async_err = reportError(mapped_error);
+   if (async_err != NO_ERROR) std::cout << "ERROR! " << "code: " << async_err << std::endl;
+   else std::cout << "No error" << std::endl;
+   otherKernel<<<100,32,0,stream>>>(out, MAX_IDX,  mapped_error2);
+   CASError::checkCuda( cudaEventRecord(finishedOtherKernel, stream) );
+
+#if 0
+   CASError::checkCuda(cudaEventSynchronize(finishedOtherKernel));
+#endif
+   async_err = reportError(mapped_error2, stream);
+   if (async_err != NO_ERROR) std::cout << "ERROR! " << "code: " << async_err << std::endl;
+   else std::cout << "No error" << std::endl;
+
+   std::cout << "Launch memcpy" << std::endl;
+   cudaMemcpyAsync(h_out, out, sizeof(float)*MAX_IDX, cudaMemcpyDeviceToHost, stream);
+   cudaStreamSynchronize(stream);
+   async_err = reportError(mapped_error);   
+   if (async_err != NO_ERROR) std::cout << "ERROR! " << "code: " << async_err << std::endl;
+   else std::cout << "No error" << std::endl;
+   mapped_error.clear(stream);   
+
+   async_err = reportError(mapped_error2, stream);
+   if (async_err != NO_ERROR) std::cout << "ERROR! " << "code: " << async_err << std::endl;
+   else std::cout << "No error" << std::endl;
+
+   int final_err = reportError(mapped_error);
+   if (final_err != NO_ERROR) std::cout << "ERROR! " << "code: " << final_err << std::endl;
+   else std::cout << "No error" << std::endl;
+
+   cudaFree(out);
+   cudaStreamDestroy(stream);
+   return 0;
+}


### PR DESCRIPTION
# Printf-alternative

Often times users may be tempted to use `printf` to signal soft warnings; however the compiler may reserve extra registers for `printf` even if the warning rarely occurs. This in turn can affect performance. The `CASerror.h` header-only library implements a performant soft-warning printf-alternative using cuda atomics and system pinned memory. An example of how to use this header-only library in action is provided in `main.cu`.