### PR TITLE
Fix overflow in type cast for GUPS benchmark

### DIFF
--- a/posts/gups/gups.cu
+++ b/posts/gups/gups.cu
@@ -390,7 +390,7 @@ int main(int argc, char* argv[])
     }
   }
 
-  size_t n_shmem = (size_t)1 << logn_shmem;
+  size_t n_shmem = 1UL << logn_shmem;
 
   int ndev;
   CUDA_RT_CALL(cudaGetDeviceCount(&ndev));
@@ -459,7 +459,7 @@ int main(int argc, char* argv[])
   }
 
   size_t n = 1UL << logn;
-  size_t working_set = (size_t)n * 100 / occupancy;
+  size_t working_set = n * 100 / occupancy;
   if (accesses_per_elem == -1) {
     if (test_type == UPDATE || test_type == UPDATE_NO_LOOP
         || test_type == READ_WRITE) {

--- a/posts/gups/gups.cu
+++ b/posts/gups/gups.cu
@@ -596,3 +596,4 @@ int main(int argc, char* argv[])
     CUDA_RT_CALL(cudaFree(d_t));
   return 0;
 }
+

--- a/posts/gups/gups.cu
+++ b/posts/gups/gups.cu
@@ -458,7 +458,7 @@ int main(int argc, char* argv[])
         prop.sharedMemPerBlockOptin));
   }
 
-  size_t n = (size_t)(1 << logn);
+  size_t n = ((size_t)1) << logn;
   size_t working_set = (size_t)n * 100 / occupancy;
   if (accesses_per_elem == -1) {
     if (test_type == UPDATE || test_type == UPDATE_NO_LOOP

--- a/posts/gups/gups.cu
+++ b/posts/gups/gups.cu
@@ -458,7 +458,7 @@ int main(int argc, char* argv[])
         prop.sharedMemPerBlockOptin));
   }
 
-  size_t n = ((size_t)1) << logn;
+  size_t n = 1UL << logn;
   size_t working_set = (size_t)n * 100 / occupancy;
   if (accesses_per_elem == -1) {
     if (test_type == UPDATE || test_type == UPDATE_NO_LOOP


### PR DESCRIPTION
## Summary
This PR fixes an integer overflow bug in the GUPS benchmark that prevents running with problem size n = 2^31.

## Changes
- Changed `size_t n = (size_t)(1 << logn)` to `size_t n = ((size_t)1) << logn` in `posts/gups/gups.cu:461`
- The issue was that `1 << logn` performs left shift on an `int` (1) before casting to `size_t`, causing overflow when `logn >= 31`
- With the fix, the cast to `size_t` happens first, allowing proper handling of large values

## Testing
This fix is required to benchmark size n = 2^31 as mentioned in issue #57.

Fixes #57